### PR TITLE
Added missing column tstamp to domain model.

### DIFF
--- a/Configuration/TCA/tx_nsguestbook_domain_model_nsguestbook.php
+++ b/Configuration/TCA/tx_nsguestbook_domain_model_nsguestbook.php
@@ -177,6 +177,11 @@ $temp = [
                 'readOnly' => 1,
             ],
         ],
+        'tstamp' => [
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
     ],
 ];
 


### PR DESCRIPTION
I found the issue for the missing date and time of the guestbook entries. I had to add the missing "tstamp" column to the domain model. I also found [this information](https://forge.typo3.org/issues/94961) which helped me to fix this issue locally. This pull request should solve issue #10.

Let me know if you need more information.